### PR TITLE
Missing Features Question

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Overview ##
-Synopsys Coverity for Jenkins simplifies running Coverity commands in Jenkins builds. 
+Synopsys Coverity for Jenkins simplifies running Coverity commands in Jenkins builds. It replaces the old Coverity Plug-In. 
 
 ## Build ##
 [![Build Status](https://travis-ci.org/jenkinsci/synopsys-coverity-plugin.svg?branch=master)](https://travis-ci.org/jenkinsci/synopsys-coverity-plugin) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=org.jenkins-ci.plugins%3Asynopsys-coverity&metric=alert_status)](https://sonarcloud.io/dashboard?id=org.jenkins-ci.plugins%3Asynopsys-coverity)


### PR DESCRIPTION
This was the only way I could seem to communicate with you since you don't have "Issues" or "Discussions" enabled.

https://plugins.jenkins.io/coverity/ says that this is the new plugin and "The functionality has been migrated onto the new Synopsys Coverity Jenkins plugin." but this plug-in is missing so many useful features that the old plug-in had.

Where is the ability to filter by Component? Where is the plot and Coverity Defects page in Jenkins?  We desperately need to be able to "fail" a Jenkins build only if there are defects found under a certain Component since our system has dozens of different Components and thousands of defects.  This was so easily done with the old plug-in but this functionality does not seem to have been migrated over.  Are there plans to add this?