### PR TITLE
SIGINT-2219: [Deprecate]  Synopsys Coverity plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+**NOTE:** This plugin is deprecated and no longer supported. It is recommended that you migrate to our new <a href="">Black Duck Security Scan</a>. Instructions can be found <a href="<community url>">here</a>.
 ## Overview ##
 Synopsys Coverity for Jenkins simplifies running Coverity commands in Jenkins builds. 
 

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ repositories {
 jenkinsPlugin {
     // Must be compatible with the version declared in Jenkins Common
     jenkinsVersion = '2.401.3' // as of version 0.40.0 of jpi, it's jenkinsVersion
-    displayName = '[DEPRECATED] Synopsys Coverity plugin'
+    displayName = 'Synopsys Coverity plugin'
     url = 'https://github.com/jenkinsci/synopsys-coverity-plugin'
     gitHubUrl = 'https://github.com/jenkinsci/synopsys-coverity-plugin'
 

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ repositories {
 jenkinsPlugin {
     // Must be compatible with the version declared in Jenkins Common
     jenkinsVersion = '2.401.3' // as of version 0.40.0 of jpi, it's jenkinsVersion
-    displayName = 'Synopsys Coverity plugin'
+    displayName = '[DEPRECATED] Synopsys Coverity plugin'
     url = 'https://github.com/jenkinsci/synopsys-coverity-plugin'
     gitHubUrl = 'https://github.com/jenkinsci/synopsys-coverity-plugin'
 


### PR DESCRIPTION
- Added the deprecation note message in the readme file.
- Need to update the migration URL and marketplace URL once they are ready.